### PR TITLE
Update postinst: changing debian stable to buster

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -19,7 +19,7 @@ case "$CODE" in
 	tessa|tina|tricia)
 		CODE=tara
 	;;
-	buster|sarah|tara|stretch|xenial|bionic|eoan)
+	bullseye|buster|sarah|tara|stretch|xenial|bionic|eoan)
 		:
 	;;
 	*)
@@ -44,9 +44,9 @@ case "$CODE" in
 				echo "Found Ubuntu $REL, using $CODE"
 			;;
 			Debian)
-				CODE=stretch
+				CODE=buster
 				if [ "$REL" = "unstable" -o "$REL" = "testing" ]; then
-					CODE=buster
+					CODE=bullseye
 				fi
 				echo "Found Debian $REL, using $CODE"
 			;;


### PR DESCRIPTION
Debian's new stable is buster, with bullseye as testing. stretch is oldstable. Should bullseye be taken into account?