### PR TITLE
Support LMDE 6 distro

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -34,6 +34,17 @@ case "$CODE" in
 				fi
 				echo "Found Linux Mint $REL, using $CODE"
 			;;
+			Linuxmint)
+				if [ "$CODE" = "faye" ] ; then
+					if [ "$REL" = "6" ]; then
+						CODE=bookworm
+						echo "Found Linux Mint Debian Edition $REL, using $CODE"
+					else
+						CODE=bullseye
+						echo "Unknown distribution found. Using $CODE as fallback."
+					fi
+				fi
+			;;
 			Ubuntu)
 				if dpkg --compare-versions 22.04 le $REL
 				then


### PR DESCRIPTION
Fixes https://github.com/Fedict/eid-archive/issues/9 by checking for CODE and REL from lsb_release and pointing to bookworm if they are resp. faye and 6, else keep falling back to bullseye.